### PR TITLE
Fix: Replace intitle with q parameter and add site support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
       "bin": {
         "stackoverflow-mcp": "cli.js"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=6.0.0"

--- a/src/stackoverflow_mcp/server.py
+++ b/src/stackoverflow_mcp/server.py
@@ -48,7 +48,8 @@ async def search_questions(
     query: str,
     limit: int = 10,
     page: int = 1,
-    sort: str = "relevance"
+    sort: str = "relevance",
+    site: str = "stackoverflow"
 ) -> Dict[str, Any]:
     """
     Search StackOverflow questions by keywords.
@@ -58,6 +59,7 @@ async def search_questions(
         limit: Maximum number of results (1-50)
         page: Page number for pagination (minimum 1)
         sort: Sort order (relevance, activity, votes, creation)
+        site: Site name to search in (e.g., stackoverflow, serverfault, askubuntu)
     """
     await server.initialize()
     
@@ -67,6 +69,7 @@ async def search_questions(
             page=page,
             page_size=min(max(1, limit), 50),
             sort=sort,
+            site=site,
             priority=RequestPriority.NORMAL
         )
         
@@ -88,7 +91,8 @@ async def search_by_tags(
     tags: List[str],
     limit: int = 10,
     page: int = 1,
-    sort: str = "activity"
+    sort: str = "activity",
+    site: str = "stackoverflow"
 ) -> Dict[str, Any]:
     """
     Search StackOverflow questions by programming tags.
@@ -98,6 +102,7 @@ async def search_by_tags(
         limit: Maximum number of results (1-50)
         page: Page number for pagination (minimum 1)
         sort: Sort order (activity, votes, creation, relevance)
+        site: Site name to search in (e.g., stackoverflow, serverfault, askubuntu)
     """
     await server.initialize()
     
@@ -107,6 +112,7 @@ async def search_by_tags(
             page=page,
             page_size=min(max(1, limit), 50),
             sort=sort,
+            site=site,
             priority=RequestPriority.NORMAL
         )
         

--- a/src/stackoverflow_mcp/stackoverflow_client.py
+++ b/src/stackoverflow_mcp/stackoverflow_client.py
@@ -1191,6 +1191,7 @@ class StackOverflowClient:
         page_size: int = 10,
         sort: str = "relevance",
         order: str = "desc",
+        site: str = "stackoverflow",
         priority: RequestPriority = RequestPriority.NORMAL
     ) -> Dict[str, Any]:
         """
@@ -1202,6 +1203,7 @@ class StackOverflowClient:
             page_size: Number of results per page (max 100)
             sort: Sort order (relevance, activity, votes, creation)
             order: Sort direction (desc, asc)
+            site: Site name to search in (default: stackoverflow)
             priority: Request priority for queue management
             
         Returns:
@@ -1222,9 +1224,10 @@ class StackOverflowClient:
         if order not in valid_orders:
             order = "desc"
         
-        # Use search/advanced endpoint with intitle parameter for keyword search
+        # Use search/advanced endpoint with q parameter for keyword search
         params = {
-            "intitle": query.strip(),  # Search in question titles
+            "q": query.strip(),  # Search query using q parameter
+            "site": site.strip(),  # Search on specific site
             "page": page,
             "pagesize": page_size,
             "sort": sort,
@@ -1255,6 +1258,7 @@ class StackOverflowClient:
         page_size: int = 10,
         sort: str = "activity",
         order: str = "desc",
+        site: str = "stackoverflow",
         priority: RequestPriority = RequestPriority.NORMAL
     ) -> Dict[str, Any]:
         """
@@ -1266,6 +1270,7 @@ class StackOverflowClient:
             page_size: Number of results per page (max 100)
             sort: Sort order (activity, votes, creation, relevance)
             order: Sort direction (desc, asc)
+            site: Site name to search in (default: stackoverflow)
             priority: Request priority for queue management
             
         Returns:
@@ -1294,6 +1299,7 @@ class StackOverflowClient:
         
         params = {
             "tagged": tagged,
+            "site": site.strip(),  # Search on specific site
             "page": page,
             "pagesize": page_size,
             "sort": sort,


### PR DESCRIPTION
Fixes #1

This PR addresses the issue where 'intitle' parameter is no longer working with the StackOverflow API.

## Changes:
- Changed `search_questions` method to use 'q' parameter instead of 'intitle' for API compatibility
- Added optional 'site' parameter to both `search_questions` and `search_by_tags` methods
- Exposed 'site' parameter in MCP server tools
- Default site is 'stackoverflow', but users can specify other sites (serverfault, askubuntu, superuser, etc.)
- Updated docstrings with new parameter documentation

## Testing:
The changes have been validated for syntax correctness and maintain backward compatibility with existing code.